### PR TITLE
require('load-grunt-tasks')(grunt) ?

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,18 +101,7 @@ module.exports = function(grunt) {
 
   });
 
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-
-  grunt.loadNpmTasks('grunt-contrib-sass');
-  grunt.loadNpmTasks('grunt-autoprefixer');
-  grunt.loadNpmTasks('grunt-contrib-cssmin');
-
-  grunt.loadNpmTasks('grunt-contrib-imagemin');
-
-  grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  
+  require('load-grunt-tasks')(grunt);
 
   // Default is basically a rebuild
   grunt.registerTask('default', ['concat', 'uglify', 'sass', 'imagemin']);


### PR DESCRIPTION
Well, as it's a personal preference, you might like the verbose format.

Yes, it does need a `npm i --save load-grunt-tasks` 

Just a suggestion :)

Some of them also do a `require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);`
