### PR TITLE
Run jshint before concat & uglify in the watch task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,7 +98,7 @@ module.exports = function(grunt) {
       },
       scripts: {
         files: ['js/*.js'],
-        tasks: ['jshint','concat', 'uglify'],
+        tasks: ['jshint', 'concat', 'uglify'],
         options: {
           spawn: false,
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,7 +98,7 @@ module.exports = function(grunt) {
       },
       scripts: {
         files: ['js/*.js'],
-        tasks: ['concat', 'uglify', 'jshint'],
+        tasks: ['jshint','concat', 'uglify'],
         options: {
           spawn: false,
         }


### PR DESCRIPTION
Since Grunt tasks are synchronous, one should lint the code he writes first not the code that is concatenated or uglifiyed.
